### PR TITLE
Remove trailing comma in JSON

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,7 @@
     "name": "secplugs/filescan",
     "description": "PHP client for the Secplugs malware analysis service for files",
     "require": {
-        "php": ">=7.4",
+        "php": ">=7.4"
     }
 }
 
-    


### PR DESCRIPTION
JSON parsing fails at packagist due to a trailing comma.